### PR TITLE
style: add order-imports rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,9 @@
           }
         ],
         "@typescript-eslint/explicit-function-return-type": "error",
-        "@typescript-eslint/explicit-member-accessibility": "error"
+        "@typescript-eslint/explicit-member-accessibility": "error",
+        "@typescript-eslint/no-unused-vars": "error",
+        "sort-imports": "error"
       }
     },
     {

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "angular.ng-template",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "bradlc.vscode-tailwindcss"
+    "bradlc.vscode-tailwindcss",
+    "amatiasq.sort-imports"
   ]
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,5 +1,6 @@
-import { NgModule } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router";
+
+import { NgModule } from "@angular/core";
 
 const routes: Routes = [];
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,6 +1,6 @@
-import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
 import { AppComponent } from "./app.component";
+import { RouterTestingModule } from "@angular/router/testing";
+import { TestBed } from "@angular/core/testing";
 
 describe("AppComponent", () => {
   beforeEach(async () => {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,11 +1,10 @@
-import { NgModule } from "@angular/core";
-import { BrowserModule } from "@angular/platform-browser";
-
-import { AppRoutingModule } from "./app-routing.module";
 import { AppComponent } from "./app.component";
+import { AppRoutingModule } from "./app-routing.module";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { BrowserModule } from "@angular/platform-browser";
+import { NgModule } from "@angular/core";
 import { ServiceWorkerModule } from "@angular/service-worker";
 import { environment } from "../environments/environment";
-import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 
 @NgModule({
   declarations: [AppComponent],

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,7 @@
-import { enableProdMode } from "@angular/core";
-import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
-
 import { AppModule } from "./app/app.module";
+import { enableProdMode } from "@angular/core";
 import { environment } from "./environments/environment";
+import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
 
 if (environment.production) {
   enableProdMode();

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,11 +1,13 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
 import "zone.js/testing";
-import { getTestBed } from "@angular/core/testing";
+
 import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting,
 } from "@angular/platform-browser-dynamic/testing";
+
+import { getTestBed } from "@angular/core/testing";
 
 declare const require: {
   context(


### PR DESCRIPTION
1. add eslint rule `order-imports` force imports to be sorted.
2. add recommend vscode plugin: `sort-imports`, which can auto sort imports instead of manually sort it.
3. sort imports in current files.