### PR TITLE
fix: husky and lint-staged not working

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn lint-staged
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "lint": "ng lint"
+    "lint": "ng lint",
+    "prepare": "husky install"
   },
   "lint-staged": {
     "src/**/*.{ts,html}": "eslint --cache --fix",
-    "src/**/*.**": "prettier --check --ignore-unknown"
+    "src/**/*.**": "prettier --check --ignore-unknown --write"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
1. Current config forgot to setup `prepare` script, husky is not auto enabled after packages installed.
2. `lint-staged` package not working when husky running pre-commit checks, changed to official recommended script content.