### PR TITLE
feat: search helper

### DIFF
--- a/src/app/modules/search/components/search-helper-item/search-helper-item.component.html
+++ b/src/app/modules/search/components/search-helper-item/search-helper-item.component.html
@@ -1,0 +1,76 @@
+<div class="flex flex-col lg:flex-row lg:space-x-2">
+  <mat-form-field>
+    <mat-label>過濾項</mat-label>
+    <mat-select [formControl]="filteringFormControl">
+      <mat-option
+        *ngFor="let option of filtrableOptions | async | keyvalue"
+        [value]="option.value"
+      >
+        {{ option.value.displayValue }}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field class="lg:w-20">
+    <mat-label>比對方式</mat-label>
+    <mat-select
+      [formControl]="compareMethodFormControl"
+      [attr.data-test]="compareMethodFormControl.value?.displayValue"
+    >
+      <mat-option
+        *ngFor="let option of compareMethodOptions | async"
+        [value]="option"
+      >
+        {{ option.displayValue }}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field class="grow" *ngIf="(isTextInput | async) === true">
+    <mat-label>比對內容</mat-label>
+    <input matInput [formControl]="compareContentTextFormControl" />
+  </mat-form-field>
+
+  <mat-form-field class="grow" *ngIf="(isTextInput | async) === false">
+    <mat-label>比對內容</mat-label>
+    <mat-chip-list #chipList class="w-full" [disabled]="!filter.filtering">
+      <mat-chip
+        *ngFor="let option of compareContentSelected | async; let index = index"
+        (removed)="onRemoveSelect(index)"
+      >
+        {{ option.displayValue }}
+        <button matChipRemove>
+          <mat-icon>cancel</mat-icon>
+        </button>
+      </mat-chip>
+      <input
+        [formControl]="compareContentSelectFormControl"
+        [matAutocomplete]="auto"
+        [matChipInputFor]="chipList"
+        [value]="compareContentSelectFormControl.value"
+      />
+    </mat-chip-list>
+    <mat-autocomplete
+      #auto="matAutocomplete"
+      autoActiveFirstOption
+      (optionSelected)="onSelectOption($event)"
+    >
+      <mat-option
+        *ngFor="let option of compareContentAvailableOptions | async"
+        [value]="option"
+      >
+        {{ option.displayValue }}
+      </mat-option>
+    </mat-autocomplete>
+  </mat-form-field>
+
+  <button
+    mat-icon-button
+    class="h-fit self-center"
+    color="warn"
+    aria-label="刪除條件"
+    (click)="removed.emit()"
+  >
+    <mat-icon>delete_forever</mat-icon>
+  </button>
+</div>

--- a/src/app/modules/search/components/search-helper-item/search-helper-item.component.scss
+++ b/src/app/modules/search/components/search-helper-item/search-helper-item.component.scss
@@ -1,0 +1,10 @@
+:host::ng-deep mat-form-field .mat-form-field-wrapper,
+:host::ng-deep mat-form-field .mat-form-field-flex {
+  height: 100%;
+}
+
+:host::ng-deep mat-form-field .mat-form-field-infix {
+  height: 100%;
+  display: flex;
+  align-items: center;
+}

--- a/src/app/modules/search/components/search-helper-item/search-helper-item.component.spec.ts
+++ b/src/app/modules/search/components/search-helper-item/search-helper-item.component.spec.ts
@@ -1,0 +1,564 @@
+import {
+  AnyFilter,
+  InputType,
+  MultipleSelectFiltrable,
+  SearchService,
+  TextFiltrable,
+} from "../../search.service";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { By } from "@angular/platform-browser";
+import { MatAutocompleteModule } from "@angular/material/autocomplete";
+import { MatButtonModule } from "@angular/material/button";
+import { MatChipsModule } from "@angular/material/chips";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatIconModule } from "@angular/material/icon";
+import { MatInputModule } from "@angular/material/input";
+import { MatSelectModule } from "@angular/material/select";
+import { MatTooltipModule } from "@angular/material/tooltip";
+import { SearchHelperItemComponent } from "./search-helper-item.component";
+
+describe("SearchHelperItemComponent", () => {
+  let component: SearchHelperItemComponent;
+  let fixture: ComponentFixture<SearchHelperItemComponent>;
+  let fakeSearchServiceData = {
+    filtrables: {
+      keyword: {
+        key: "keyword",
+        displayValue: "關鍵字",
+        compareMethods: [
+          {
+            key: "includes",
+            displayValue: "包含",
+          },
+          {
+            key: "not-includes",
+            displayValue: "不包含",
+          },
+        ],
+        compareContent: {
+          inputType: InputType.Text,
+        },
+      } as TextFiltrable,
+      type: {
+        key: "type",
+        displayValue: "修別",
+        compareMethods: [
+          {
+            key: "is",
+            displayValue: "是",
+          },
+        ],
+        compareContent: {
+          inputType: InputType.MultipleSelect,
+          selectables: [
+            { key: "required", displayValue: "必修" },
+            { key: "required-optional", displayValue: "必選" },
+            { key: "optional", displayValue: "選修" },
+            { key: "general", displayValue: "通識" },
+          ],
+        },
+      } as MultipleSelectFiltrable,
+    },
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SearchHelperItemComponent],
+      imports: [
+        BrowserAnimationsModule,
+        FormsModule,
+        ReactiveFormsModule,
+        MatFormFieldModule,
+        MatAutocompleteModule,
+        MatButtonModule,
+        MatChipsModule,
+        MatIconModule,
+        MatTooltipModule,
+        MatInputModule,
+        MatSelectModule,
+      ],
+      providers: [{ provide: SearchService, useValue: fakeSearchServiceData }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SearchHelperItemComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe("filtering", () => {
+    it("should be able to initialize null value when no input", () => {
+      const compareKey = fixture.nativeElement.querySelector(
+        "mat-form-field:nth-child(1)",
+      );
+      expect(compareKey.textContent).toBe("過濾項");
+    });
+
+    it("should list selectable filtering options", async () => {
+      const compareKey = fixture.nativeElement.querySelector(
+        "mat-form-field:nth-child(1) mat-select",
+      );
+      compareKey.click();
+      fixture.autoDetectChanges(true);
+      await fixture.whenStable();
+
+      const compareKeyOptions = fixture.debugElement.queryAll(
+        By.css(".mat-option"),
+      );
+      expect(compareKeyOptions.length).toBe(
+        Object.values(fakeSearchServiceData.filtrables).length,
+      );
+    });
+
+    it("should be able to initialize selected value", async () => {
+      const testFiltrable = fakeSearchServiceData.filtrables.type;
+      component.filter = {
+        filtering: testFiltrable,
+        compareMethod: null,
+        compareContent: null,
+      };
+      component.ngOnInit();
+      fixture.autoDetectChanges(true);
+      await fixture.whenStable();
+
+      const compareKey = fixture.nativeElement.querySelector(
+        "mat-form-field:nth-child(1) mat-select",
+      );
+      expect(compareKey.textContent).toBe(testFiltrable.displayValue);
+    });
+
+    it("should be able to change selected value", async () => {
+      const testFiltrable = fakeSearchServiceData.filtrables.type;
+      component.filter = {
+        filtering: testFiltrable,
+        compareMethod: null,
+        compareContent: null,
+      } as AnyFilter;
+      component.ngOnInit();
+      fixture.autoDetectChanges(true);
+      await fixture.whenStable();
+
+      const compareKey = fixture.nativeElement.querySelector(
+        "mat-form-field:nth-child(1) mat-select",
+      );
+      compareKey.click();
+      fixture.autoDetectChanges(true);
+      await fixture.whenStable();
+
+      fixture.debugElement
+        .queryAll(By.css(".mat-option"))
+        .find(
+          element =>
+            element.nativeElement.textContent.trim() ===
+            fakeSearchServiceData.filtrables.keyword.displayValue,
+        )
+        ?.nativeElement.click();
+      fixture.autoDetectChanges(true);
+      await fixture.whenStable();
+
+      expect(component.filter.filtering).toEqual(
+        fakeSearchServiceData.filtrables.keyword,
+      );
+    });
+  });
+
+  describe("compareMethod", () => {
+    it("should be able to initialize null value when no input", () => {
+      const compareType = fixture.nativeElement.querySelector(
+        "mat-form-field:nth-child(2)",
+      );
+      expect(compareType.textContent).toBe("比對方式");
+    });
+
+    it("should list selectable compare methods", async () => {
+      const testFiltrable = fakeSearchServiceData.filtrables.keyword;
+      component.filter = {
+        filtering: testFiltrable,
+        compareMethod: null,
+        compareContent: null,
+      };
+      component.ngOnInit();
+      fixture.autoDetectChanges(true);
+      await fixture.whenStable();
+
+      const compareType = fixture.nativeElement.querySelector(
+        "mat-form-field:nth-child(2) mat-select",
+      );
+      compareType.click();
+      fixture.autoDetectChanges(true);
+      await fixture.whenStable();
+
+      const compareTypeOptions = fixture.debugElement.queryAll(
+        By.css(".mat-option"),
+      );
+      expect(compareTypeOptions.length).toBe(
+        testFiltrable.compareMethods.length,
+      );
+    });
+
+    it("should update selectable compare methods when filtering changes", async () => {
+      const testFiltrable = fakeSearchServiceData.filtrables.type;
+      component.filter = {
+        filtering: testFiltrable,
+        compareMethod: null,
+        compareContent: null,
+      };
+      component.ngOnInit();
+      fixture.autoDetectChanges(true);
+      await fixture.whenStable();
+
+      const compareType = fixture.nativeElement.querySelector(
+        "mat-form-field:nth-child(2) mat-select",
+      );
+      compareType.click();
+      fixture.autoDetectChanges(true);
+      await fixture.whenStable();
+
+      let compareTypeOptions = fixture.debugElement.queryAll(
+        By.css(".mat-option"),
+      );
+      expect(compareTypeOptions.length).toBe(
+        testFiltrable.compareMethods.length,
+      );
+
+      const compareKey = fixture.nativeElement.querySelector(
+        "mat-form-field:nth-child(1) mat-select",
+      );
+      compareKey.click();
+      fixture.autoDetectChanges(true);
+      await fixture.whenStable();
+
+      fixture.debugElement
+        .queryAll(By.css(".mat-option"))
+        .find(
+          element =>
+            element.nativeElement.textContent.trim() ===
+            fakeSearchServiceData.filtrables.keyword.displayValue,
+        )
+        ?.nativeElement.click();
+      fixture.autoDetectChanges(true);
+      await fixture.whenStable();
+
+      compareType.click();
+      fixture.autoDetectChanges(true);
+      await fixture.whenStable();
+
+      compareTypeOptions = fixture.debugElement.queryAll(By.css(".mat-option"));
+      expect(compareTypeOptions.length).toBe(
+        fakeSearchServiceData.filtrables.keyword.compareMethods.length,
+      );
+    });
+
+    it("should be able to initialize selected value", async () => {
+      const testFiltrable = fakeSearchServiceData.filtrables.keyword;
+      component.filter = {
+        filtering: testFiltrable,
+        compareMethod: testFiltrable.compareMethods[0],
+        compareContent: null,
+      };
+      component.ngOnInit();
+      fixture.autoDetectChanges(true);
+      await fixture.whenStable();
+
+      const compareType = fixture.nativeElement.querySelector(
+        "mat-form-field:nth-child(2) mat-select",
+      );
+      expect(compareType.textContent).toBe(
+        testFiltrable.compareMethods[0].displayValue,
+      );
+    });
+
+    it("should be able to change selected value", async () => {
+      const testFiltrable = fakeSearchServiceData.filtrables.keyword;
+      component.filter = {
+        filtering: testFiltrable,
+        compareMethod: testFiltrable.compareMethods[0],
+        compareContent: null,
+      };
+      component.ngOnInit();
+      fixture.autoDetectChanges(true);
+      await fixture.whenStable();
+
+      const compareType = fixture.nativeElement.querySelector(
+        "mat-form-field:nth-child(2) mat-select",
+      );
+      compareType.click();
+      fixture.autoDetectChanges(true);
+      await fixture.whenStable();
+
+      fixture.debugElement
+        .queryAll(By.css(".mat-option"))
+        .find(
+          element =>
+            element.nativeElement.textContent.trim() ===
+            testFiltrable.compareMethods[1].displayValue,
+        )
+        ?.nativeElement.click();
+      fixture.autoDetectChanges(true);
+      await fixture.whenStable();
+
+      expect(component.filter.compareMethod).toEqual(
+        testFiltrable.compareMethods[1],
+      );
+    });
+  });
+
+  describe("compareContent", () => {
+    it("should be able to initialize null value when no input", () => {
+      const compareContent = fixture.nativeElement.querySelector(
+        "mat-form-field:nth-child(3)",
+      );
+      expect(compareContent.textContent).toBe("比對內容");
+    });
+
+    describe("text type", () => {
+      it("should be able to initialize text values", async () => {
+        const testFiltrable = fakeSearchServiceData.filtrables.keyword;
+
+        component.filter = {
+          filtering: testFiltrable,
+          compareMethod: null,
+          compareContent: "Test Content",
+        };
+        component.ngOnInit();
+        fixture.autoDetectChanges(true);
+        await fixture.whenStable();
+
+        const textCompareContent = fixture.nativeElement.querySelector(
+          "mat-form-field:nth-child(3) input",
+        );
+
+        expect(textCompareContent.value).toContain("Test Content");
+      });
+
+      it("should be able to change inputted value", async () => {
+        const testFiltrable = fakeSearchServiceData.filtrables.keyword;
+        component.filter = {
+          filtering: testFiltrable,
+          compareMethod: testFiltrable.compareMethods[0],
+          compareContent: "test",
+        };
+        component.ngOnInit();
+        fixture.autoDetectChanges(true);
+        await fixture.whenStable();
+
+        const compareContent = fixture.nativeElement.querySelector(
+          "mat-form-field:nth-child(3) input",
+        );
+        compareContent.value = "test2";
+        compareContent.dispatchEvent(new Event("input"));
+        fixture.autoDetectChanges(true);
+        await fixture.whenStable();
+
+        expect(component.filter.compareContent).toBe("test2");
+      });
+    });
+
+    describe("multiple-select type", () => {
+      it("should list selectable compare methods", async () => {
+        const testFiltrable = fakeSearchServiceData.filtrables.type;
+        component.filter = {
+          filtering: testFiltrable,
+          compareMethod: null,
+          compareContent: null,
+        };
+        component.ngOnInit();
+        fixture.autoDetectChanges(true);
+        await fixture.whenStable();
+
+        const compareContent = fixture.nativeElement.querySelector(
+          "mat-form-field:nth-child(3) input",
+        );
+        compareContent.click();
+        fixture.autoDetectChanges(true);
+        await fixture.whenStable();
+
+        const compareContentOptions = fixture.debugElement.queryAll(
+          By.css(".mat-option"),
+        );
+        expect(compareContentOptions.length).toBe(
+          testFiltrable.compareContent.selectables.length,
+        );
+      });
+
+      it("should update selectable compare methods when filtering changed", async () => {
+        const filtering = fixture.nativeElement.querySelector(
+          "mat-form-field:nth-child(1) mat-select",
+        );
+        filtering.click();
+        fixture.autoDetectChanges(true);
+        await fixture.whenStable();
+
+        fixture.debugElement
+          .queryAll(By.css(".mat-option"))
+          .find(
+            element =>
+              element.nativeElement.textContent.trim() ===
+              fakeSearchServiceData.filtrables.type.displayValue,
+          )
+          ?.nativeElement.click();
+        fixture.autoDetectChanges(true);
+        await fixture.whenStable();
+
+        const compareContent = fixture.nativeElement.querySelector(
+          "mat-form-field:nth-child(3) input",
+        );
+        compareContent.click();
+        fixture.autoDetectChanges(true);
+        await fixture.whenStable();
+
+        const compareContentOptions = fixture.debugElement.queryAll(
+          By.css(".mat-option"),
+        );
+        expect(compareContentOptions.length).toBe(
+          fakeSearchServiceData.filtrables.type.compareContent.selectables
+            .length,
+        );
+      });
+
+      it("should be able to initialize selected values", async () => {
+        const testFiltrable = fakeSearchServiceData.filtrables.type;
+
+        component.filter = {
+          filtering: testFiltrable,
+          compareMethod: null,
+          compareContent: [
+            testFiltrable.compareContent.selectables[0],
+            testFiltrable.compareContent.selectables[1],
+          ],
+        };
+        component.ngOnInit();
+        fixture.autoDetectChanges(true);
+        await fixture.whenStable();
+
+        const selectedCompareContent = fixture.nativeElement.querySelectorAll(
+          "mat-form-field:nth-child(3) mat-chip",
+        );
+        expect(selectedCompareContent.length)
+          .withContext("多選比對內容長度")
+          .toBe(2);
+        expect(selectedCompareContent[0].textContent)
+          .withContext("第一個多選比對內容")
+          .toContain(testFiltrable.compareContent.selectables[0].displayValue);
+        expect(selectedCompareContent[1].textContent)
+          .withContext("第二個多選比對內容")
+          .toContain(testFiltrable.compareContent.selectables[1].displayValue);
+      });
+
+      it("should update selectable compare methods when enter text", async () => {
+        const testFiltrable = fakeSearchServiceData.filtrables.type;
+        component.filter = {
+          filtering: testFiltrable,
+          compareMethod: null,
+          compareContent: null,
+        };
+        component.ngOnInit();
+        fixture.autoDetectChanges(true);
+        await fixture.whenStable();
+
+        const compareContent = fixture.debugElement.query(
+          By.css("mat-form-field:nth-child(3) input"),
+        ).nativeElement;
+        compareContent.click();
+        await fixture.whenStable();
+
+        compareContent.value =
+          testFiltrable.compareContent.selectables[0].displayValue;
+        compareContent.dispatchEvent(new Event("input"));
+        await fixture.whenStable();
+
+        let compareContentOptions = fixture.debugElement.queryAll(
+          By.css(".mat-option"),
+        );
+        expect(compareContentOptions.length).toBe(1);
+        expect(compareContentOptions[0].nativeElement.textContent.trim()).toBe(
+          testFiltrable.compareContent.selectables[0].displayValue,
+        );
+      });
+
+      it("should be able to select value and remove selected values from selectable compare methods", async () => {
+        const testFiltrable = fakeSearchServiceData.filtrables.type;
+        component.filter = {
+          filtering: testFiltrable,
+          compareMethod: null,
+          compareContent: null,
+        };
+        component.ngOnInit();
+        fixture.autoDetectChanges(true);
+        await fixture.whenStable();
+
+        const compareContent = fixture.nativeElement.querySelector(
+          "mat-form-field:nth-child(3) input",
+        );
+        compareContent.click();
+        await fixture.whenStable();
+
+        const compareContentOption = fixture.debugElement.query(
+          By.css(".mat-option"),
+        );
+        compareContentOption.nativeElement.click();
+        await fixture.whenStable();
+
+        expect(component.filter.compareContent).toEqual([
+          testFiltrable.compareContent.selectables[0],
+        ]);
+
+        compareContent.click();
+        await fixture.whenStable();
+
+        const compareContentOptions = fixture.debugElement.queryAll(
+          By.css(".mat-option"),
+        );
+        expect(compareContentOptions.length).toBe(
+          testFiltrable.compareContent.selectables.length - 1,
+        );
+        expect(
+          compareContentOptions.map(element =>
+            element.nativeElement.textContent.trim(),
+          ),
+        ).not.toContain(
+          testFiltrable.compareContent.selectables[0].displayValue,
+        );
+      });
+
+      it("should be able to remove selected value", async () => {
+        const testFiltrable = fakeSearchServiceData.filtrables.type;
+        component.filter = {
+          filtering: testFiltrable,
+          compareMethod: null,
+          compareContent: [
+            testFiltrable.compareContent.selectables[0],
+            testFiltrable.compareContent.selectables[1],
+          ],
+        };
+        component.ngOnInit();
+        fixture.autoDetectChanges(true);
+        await fixture.whenStable();
+
+        const selectedCompareContent = fixture.debugElement.query(
+          By.css("mat-form-field:nth-child(3) mat-chip button"),
+        ).nativeElement;
+        selectedCompareContent.click();
+        await fixture.whenStable();
+
+        expect(component.filter.compareContent).toEqual([
+          testFiltrable.compareContent.selectables[1],
+        ]);
+      });
+    });
+  });
+
+  describe("remove button", () => {
+    it("should emit removed event when remove button clicked", () => {
+      spyOn(component.removed, "emit");
+      fixture.nativeElement.querySelector(":scope > div > button").click();
+      expect(component.removed.emit).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/modules/search/components/search-helper-item/search-helper-item.component.ts
+++ b/src/app/modules/search/components/search-helper-item/search-helper-item.component.ts
@@ -1,0 +1,247 @@
+import {
+  AnyFilter,
+  AnyFiltrable,
+  ComparableMultipleSelect,
+  CompareMethod,
+  InputType,
+  MultipleSelectFilter,
+  SearchService,
+  Selectable,
+  TextFilter,
+} from "../../search.service";
+import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
+
+import { BehaviorSubject } from "rxjs";
+import { FormControl } from "@angular/forms";
+import { MatAutocompleteSelectedEvent } from "@angular/material/autocomplete";
+
+@Component({
+  selector: "app-search-helper-item",
+  templateUrl: "./search-helper-item.component.html",
+  styleUrls: ["./search-helper-item.component.scss"],
+})
+export class SearchHelperItemComponent implements OnInit {
+  @Input() public filter: AnyFilter = {
+    filtering: null,
+    compareMethod: null,
+    compareContent: null,
+  };
+
+  @Output() public removed: EventEmitter<string> = new EventEmitter();
+
+  public constructor(protected searchService: SearchService) {}
+
+  public ngOnInit(): void {
+    this._initializeFiltering();
+    this._initializeCompareMethod();
+    this._initializeCompareContent();
+  }
+
+  // Part 1: Filtrable selection
+
+  protected filtrableOptions = new BehaviorSubject<
+    Record<string, AnyFiltrable>
+  >({});
+  protected filteringFormControl: FormControl<AnyFiltrable | null> =
+    new FormControl();
+
+  private _initializeFiltering(): void {
+    this.filtrableOptions.next(this.searchService.filtrables);
+    this.filteringFormControl = new FormControl(this.filter.filtering);
+    this.filteringFormControl.valueChanges.subscribe(filtering =>
+      this._onFilteringFormControlValueChange(filtering),
+    );
+  }
+
+  private _onFilteringFormControlValueChange(
+    filtering: AnyFiltrable | null,
+  ): void {
+    this.filter.filtering = filtering;
+    this.filter.compareMethod = null;
+    this.filter.compareContent = null;
+
+    this._initializeCompareMethod();
+    this._initializeCompareContent();
+  }
+
+  // Part 2: Compare Method
+
+  /** Options of compare content that available for select */
+  protected compareMethodOptions = new BehaviorSubject<Selectable[]>([]);
+  protected compareMethodFormControl: FormControl<CompareMethod | null> =
+    new FormControl();
+
+  /**
+   * Initialize pre-inputted text and related observers.
+   */
+  private _initializeCompareMethod(): void {
+    const compareMethods = this.filter.filtering?.compareMethods ?? [];
+    this.compareMethodOptions.next(compareMethods);
+    this.compareMethodFormControl = new FormControl(this.filter.compareMethod);
+    this.compareMethodFormControl.valueChanges.subscribe(compareMethod =>
+      this._onCompareMethodFormControlValueChange(compareMethod),
+    );
+
+    if (this.filter.filtering) {
+      this.compareMethodFormControl.enable();
+    } else {
+      this.compareMethodFormControl.disable();
+    }
+  }
+
+  /**
+   * Event handler for value change event of `compareMethodFormControl` FormControl .
+   * @param compareMethod user selected compareMethod
+   */
+  private _onCompareMethodFormControlValueChange(
+    compareMethod: CompareMethod | null,
+  ): void {
+    this.filter.compareMethod = compareMethod;
+  }
+
+  // Part 3: Compare Content
+
+  protected isTextInput = new BehaviorSubject(false);
+
+  private _initializeCompareContent(): void {
+    this.isTextInput.next(
+      this.filter.filtering?.compareContent.inputType === InputType.Text,
+    );
+    if (this.isTextInput.observed) return;
+    this.isTextInput.subscribe(isTextInput =>
+      this._onIsTextInputChange(isTextInput),
+    );
+  }
+
+  private _onIsTextInputChange(isTextInput: boolean): void {
+    if (isTextInput) {
+      this._initializeCompareContentText();
+    } else {
+      this._initializeCompareContentSelect();
+    }
+  }
+
+  // Part 3-1: Text-type Compare Content
+
+  /** FormControl object for input of text-type compare content */
+  protected compareContentTextFormControl: FormControl<string> =
+    new FormControl("", { nonNullable: true });
+
+  /**
+   * Initialize pre-inputted text and related observers.
+   */
+  private _initializeCompareContentText(): void {
+    this.compareContentTextFormControl.reset();
+    this.compareContentTextFormControl = new FormControl(
+      (this.filter as TextFilter).compareContent ?? "",
+      { nonNullable: true },
+    );
+    this.compareContentTextFormControl.valueChanges.subscribe(value =>
+      this._onCompareContentTextFormControlValueChange(value),
+    );
+  }
+
+  /**
+   * Event handler for value change event of `compareContentTextFormControl` FormControl .
+   * @param value user inputted text
+   */
+  private _onCompareContentTextFormControlValueChange(value: string): void {
+    this.filter.compareContent = value;
+  }
+
+  // Part 3-2: Select-type Compare Content
+
+  /** Options of compare content that available for select */
+  protected compareContentAvailableOptions = new BehaviorSubject<Selectable[]>(
+    [],
+  );
+  /** User selected options */
+  protected compareContentSelected = new BehaviorSubject<Selectable[]>([]);
+  /** FormControl object for input of select-type compare content */
+  protected compareContentSelectFormControl: FormControl<string> =
+    new FormControl();
+
+  /**
+   * Initialize pre-selected options, update available options and related observers.
+   */
+  private _initializeCompareContentSelect(): void {
+    const compareContent = this.filter.filtering?.compareContent;
+    if (compareContent?.inputType !== InputType.MultipleSelect) return;
+    this.compareContentAvailableOptions.next(compareContent.selectables);
+    this.compareContentSelected.next(
+      (this.filter as MultipleSelectFilter).compareContent ?? [],
+    );
+    this.compareContentSelectFormControl.valueChanges.subscribe(() =>
+      this._onCompareContentSelectFormControlValueChange(),
+    );
+    this.compareContentSelected.subscribe(selected =>
+      this._onCompareContentSelectedChange(selected),
+    );
+  }
+
+  /**
+   * Event handler for value change event of `compareContentSelectFormControl`.
+   */
+  private async _onCompareContentSelectFormControlValueChange(): Promise<void> {
+    this._updateAvailableOptions();
+  }
+
+  /**
+   * Update available options based on user inputted text.
+   */
+  private async _updateAvailableOptions(): Promise<void> {
+    const userInputtedValue = this.compareContentSelectFormControl.value ?? "";
+    const availableOptions =
+      this._getAvailableCompareContentOptions(userInputtedValue);
+    this.compareContentAvailableOptions.next(availableOptions);
+  }
+
+  /**
+   * Event handler for variable `compareContentSelected` changed. Will update available options.
+   */
+  private _onCompareContentSelectedChange(selected: Selectable[]): void {
+    this.filter.compareContent = selected;
+    this._updateAvailableOptions();
+  }
+
+  /**
+   * UI Event handler for adding user selected option into data, also clear user inputted text.
+   * @param event autocomplete selected event
+   */
+  protected onSelectOption(event: MatAutocompleteSelectedEvent): void {
+    const selected = this.compareContentSelected.value;
+    selected.push(event.option.value);
+    this.compareContentSelected.next(selected);
+    this.compareContentSelectFormControl.setValue("");
+  }
+
+  /**
+   * UI Event handler for removing selected option.
+   * @param index item index in array
+   */
+  protected onRemoveSelect(index: number): void {
+    const selected = this.compareContentSelected.value;
+    selected.splice(index, 1);
+    this.compareContentSelected.next(selected);
+  }
+
+  /**
+   * Get available options by inputted text, also filter out selected options.
+   * @param value user inputted text or any text to filter options
+   * @returns available options
+   */
+  private _getAvailableCompareContentOptions(value: string): Selectable[] {
+    const filterValue = value.toString().toLowerCase();
+
+    const compareContent = this.filter.filtering
+      ?.compareContent as ComparableMultipleSelect;
+    const selected = this.compareContentSelected.value;
+
+    return compareContent.selectables.filter(option => {
+      const isMatch = option.displayValue.toLowerCase().includes(filterValue);
+      const isAlreadySelected = selected.includes(option);
+
+      return isMatch && !isAlreadySelected;
+    });
+  }
+}

--- a/src/app/modules/search/components/search-helper/search-helper.component.html
+++ b/src/app/modules/search/components/search-helper/search-helper.component.html
@@ -1,0 +1,16 @@
+<app-search-helper-item
+  *ngFor="let filter of this.filters; let index = index"
+  [filter]="filter"
+  (removed)="removeFilter(index)"
+></app-search-helper-item>
+
+<div class="mt-5 text-center">
+  <button
+    mat-stroked-button
+    matTooltip="新增過濾條件"
+    aria-label="新增過濾條件的按鈕"
+    (click)="addFilter()"
+  >
+    <mat-icon>add</mat-icon>
+  </button>
+</div>

--- a/src/app/modules/search/components/search-helper/search-helper.component.spec.ts
+++ b/src/app/modules/search/components/search-helper/search-helper.component.spec.ts
@@ -1,0 +1,80 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { By } from "@angular/platform-browser";
+import { MatAutocompleteModule } from "@angular/material/autocomplete";
+import { MatChipsModule } from "@angular/material/chips";
+import { MatIconModule } from "@angular/material/icon";
+import { MatSelectModule } from "@angular/material/select";
+import { SearchHelperComponent } from "./search-helper.component";
+import { SearchHelperItemComponent } from "../search-helper-item/search-helper-item.component";
+import { SearchService } from "../../search.service";
+
+describe("SearchHelperComponent", () => {
+  let component: SearchHelperComponent;
+  let fixture: ComponentFixture<SearchHelperComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SearchHelperComponent, SearchHelperItemComponent],
+      imports: [
+        BrowserAnimationsModule,
+        FormsModule,
+        ReactiveFormsModule,
+        MatAutocompleteModule,
+        MatChipsModule,
+        MatIconModule,
+        MatSelectModule,
+      ],
+      providers: [{ provide: SearchService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SearchHelperComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("should have a default empty filter", () => {
+    const searchHelperItems = fixture.nativeElement.querySelectorAll(
+      "app-search-helper-item",
+    );
+    expect(searchHelperItems.length).toEqual(1);
+  });
+
+  describe("add filter button", () => {
+    it("should add a filter", () => {
+      const addFilterButton = fixture.debugElement.nativeElement.querySelector(
+        "app-search-helper-item + div > button",
+      );
+      addFilterButton.click();
+
+      fixture.detectChanges();
+
+      const searchHelperItems =
+        fixture.debugElement.nativeElement.querySelectorAll(
+          "app-search-helper-item",
+        );
+      expect(searchHelperItems.length).toBe(2);
+    });
+  });
+
+  it("should remove a filter when event emits from item", () => {
+    const firstItem = fixture.debugElement.query(
+      By.css("app-search-helper-item"),
+    ).componentInstance as SearchHelperItemComponent;
+    firstItem.removed.emit();
+
+    fixture.detectChanges();
+
+    const searchHelperItems =
+      fixture.debugElement.nativeElement.querySelectorAll(
+        "app-search-helper-item",
+      );
+    expect(searchHelperItems.length).toBe(0);
+  });
+});

--- a/src/app/modules/search/components/search-helper/search-helper.component.ts
+++ b/src/app/modules/search/components/search-helper/search-helper.component.ts
@@ -1,0 +1,33 @@
+import { AnyFilter, SearchService } from "../../search.service";
+import { Component, OnDestroy, OnInit } from "@angular/core";
+
+@Component({
+  selector: "app-search-helper",
+  templateUrl: "./search-helper.component.html",
+  styleUrls: ["./search-helper.component.scss"],
+})
+export class SearchHelperComponent implements OnInit, OnDestroy {
+  protected filters: AnyFilter[] = [];
+  public constructor(protected searchService: SearchService) {}
+
+  public ngOnInit(): void {
+    this.filters = this.searchService.filters;
+    if (!this.filters.length) this.addFilter();
+  }
+
+  protected addFilter(): void {
+    this.filters.push({
+      filtering: null,
+      compareMethod: null,
+      compareContent: null,
+    });
+  }
+
+  protected removeFilter(index: number): void {
+    this.filters.splice(index, 1);
+  }
+
+  public ngOnDestroy(): void {
+    this.searchService.filters = this.filters;
+  }
+}

--- a/src/app/modules/search/search-routing.module.ts
+++ b/src/app/modules/search/search-routing.module.ts
@@ -1,0 +1,11 @@
+import { RouterModule, Routes } from "@angular/router";
+
+import { NgModule } from "@angular/core";
+
+const routes: Routes = [];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class SearchRoutingModule {}

--- a/src/app/modules/search/search.module.ts
+++ b/src/app/modules/search/search.module.ts
@@ -1,0 +1,34 @@
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+
+import { CommonModule } from "@angular/common";
+import { MatAutocompleteModule } from "@angular/material/autocomplete";
+import { MatButtonModule } from "@angular/material/button";
+import { MatChipsModule } from "@angular/material/chips";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatIconModule } from "@angular/material/icon";
+import { MatInputModule } from "@angular/material/input";
+import { MatSelectModule } from "@angular/material/select";
+import { MatTooltipModule } from "@angular/material/tooltip";
+import { NgModule } from "@angular/core";
+import { SearchHelperComponent } from "./components/search-helper/search-helper.component";
+import { SearchHelperItemComponent } from "./components/search-helper-item/search-helper-item.component";
+import { SearchRoutingModule } from "./search-routing.module";
+
+@NgModule({
+  declarations: [SearchHelperComponent, SearchHelperItemComponent],
+  imports: [
+    CommonModule,
+    SearchRoutingModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatAutocompleteModule,
+    MatButtonModule,
+    MatChipsModule,
+    MatIconModule,
+    MatTooltipModule,
+    MatInputModule,
+    MatSelectModule,
+  ],
+})
+export class SearchModule {}

--- a/src/app/modules/search/search.service.spec.ts
+++ b/src/app/modules/search/search.service.spec.ts
@@ -1,0 +1,64 @@
+import { SearchService } from "./search.service";
+import { TestBed } from "@angular/core/testing";
+
+describe("SearchService", () => {
+  let service: SearchService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SearchService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe("#searchHelperEnabled", () => {
+    it("should be observable and return a default false value", (done: DoneFn) => {
+      service.searchHelperEnabled.subscribe(value => {
+        expect(value).toBe(false);
+        done();
+      });
+    });
+  });
+
+  describe("#disableSearchHelper()", () => {
+    it("should set #searchHelperEnabled to false", (done: DoneFn) => {
+      service.disableSearchHelper();
+      service.searchHelperEnabled.subscribe(value => {
+        expect(value).toBe(false);
+        done();
+      });
+    });
+  });
+
+  describe("#enableSearchHelper()", () => {
+    it("should set #searchHelperEnabled to true", (done: DoneFn) => {
+      service.enableSearchHelper();
+      service.searchHelperEnabled.subscribe(value => {
+        expect(value).toBe(true);
+        done();
+      });
+    });
+  });
+
+  describe("#toggleSearchHelper()", () => {
+    it("should toggle #searchHelperEnabled from false to true", (done: DoneFn) => {
+      service.disableSearchHelper();
+      service.toggleSearchHelper();
+      service.searchHelperEnabled.subscribe(value => {
+        expect(value).toBe(true);
+        done();
+      });
+    });
+
+    it("should toggle #searchHelperEnabled from true to false", (done: DoneFn) => {
+      service.enableSearchHelper();
+      service.toggleSearchHelper();
+      service.searchHelperEnabled.subscribe(value => {
+        expect(value).toBe(false);
+        done();
+      });
+    });
+  });
+});

--- a/src/app/modules/search/search.service.ts
+++ b/src/app/modules/search/search.service.ts
@@ -1,0 +1,305 @@
+import { BehaviorSubject } from "rxjs";
+import { Injectable } from "@angular/core";
+
+@Injectable({
+  providedIn: "root",
+})
+export class SearchService {
+  public filtrables: Record<string, AnyFiltrable> = {
+    teacher: {
+      key: "teacher",
+      displayValue: "授課教師",
+      compareMethods: [
+        {
+          key: "includes",
+          displayValue: "包含",
+        },
+        {
+          key: "not-includes",
+          displayValue: "不包含",
+        },
+      ],
+      compareContent: {
+        inputType: InputType.MultipleSelect,
+        selectables: [
+          { key: "時乃空", displayValue: "時乃空" },
+          { key: "蘿蔔子", displayValue: "蘿蔔子" },
+          { key: "星街彗星", displayValue: "星街彗星" },
+          { key: "櫻巫女", displayValue: "櫻巫女" },
+          { key: "AZKi", displayValue: "AZKi" },
+          { key: "夜空梅露", displayValue: "夜空梅露" },
+          { key: "白上吹雪", displayValue: "白上吹雪" },
+          { key: "亞綺·羅森塔爾", displayValue: "亞綺·羅森塔爾" },
+          { key: "夏色祭", displayValue: "夏色祭" },
+          { key: "赤井心", displayValue: "赤井心" },
+          { key: "湊阿庫婭", displayValue: "湊阿庫婭" },
+          { key: "紫咲詩音", displayValue: "紫咲詩音" },
+          { key: "百鬼綾目", displayValue: "百鬼綾目" },
+          { key: "癒月巧可", displayValue: "癒月巧可" },
+          { key: "大空昴", displayValue: "大空昴" },
+          { key: "白上吹雪", displayValue: "白上吹雪" },
+          { key: "大神澪", displayValue: "大神澪" },
+          { key: "貓又小粥", displayValue: "貓又小粥" },
+          { key: "戌神沁音", displayValue: "戌神沁音" },
+          { key: "兔田佩克拉", displayValue: "兔田佩克拉" },
+          { key: "潤羽露西婭", displayValue: "潤羽露西婭" },
+          { key: "不知火芙蕾雅", displayValue: "不知火芙蕾雅" },
+          { key: "白銀諾艾爾", displayValue: "白銀諾艾爾" },
+          { key: "寶鐘瑪琳", displayValue: "寶鐘瑪琳" },
+          { key: "天音彼方", displayValue: "天音彼方" },
+          { key: "桐生可可", displayValue: "桐生可可" },
+          { key: "角卷綿芽", displayValue: "角卷綿芽" },
+          { key: "常闇永遠", displayValue: "常闇永遠" },
+          { key: "姬森璐娜", displayValue: "姬森璐娜" },
+          { key: "雪花菈米", displayValue: "雪花菈米" },
+          { key: "桃鈴音音", displayValue: "桃鈴音音" },
+          { key: "獅白牡丹", displayValue: "獅白牡丹" },
+          { key: "尾丸波爾卡", displayValue: "尾丸波爾卡" },
+          { key: "拉普拉斯·達克尼斯", displayValue: "拉普拉斯·達克尼斯" },
+          { key: "鷹嶺琉衣", displayValue: "鷹嶺琉衣" },
+          { key: "博衣小夜璃", displayValue: "博衣小夜璃" },
+          { key: "沙花叉克蘿耶", displayValue: "沙花叉克蘿耶" },
+          { key: "風真伊呂波", displayValue: "風真伊呂波" },
+          { key: "友人A", displayValue: "友人A" },
+          { key: "春先和花", displayValue: "春先和花" },
+        ],
+      },
+    },
+    time: {
+      key: "time",
+      displayValue: "上課時間",
+      compareMethods: [
+        {
+          key: "includes",
+          displayValue: "包含",
+        },
+        {
+          key: "not-includes",
+          displayValue: "不包含",
+        },
+      ],
+      compareContent: {
+        inputType: InputType.MultipleSelect,
+        selectables: [
+          { key: "1-1", displayValue: "1-1 週一 第一節" },
+          { key: "1-2", displayValue: "1-2 週一 第二節" },
+          { key: "1-3", displayValue: "1-3 週一 第三節" },
+          { key: "1-4", displayValue: "1-4 週一 第四節" },
+          { key: "1-5", displayValue: "1-5 週一 第五節" },
+          { key: "1-6", displayValue: "1-6 週一 第六節" },
+          { key: "1-7", displayValue: "1-7 週一 第七節" },
+          { key: "1-8", displayValue: "1-8 週一 第八節" },
+          { key: "1-9", displayValue: "1-9 週一 第九節" },
+          { key: "1-10", displayValue: "1-10 週一 第十節" },
+          { key: "1-11", displayValue: "1-11 週一 第十一節" },
+          { key: "1-12", displayValue: "1-12 週一 第十二節" },
+          { key: "1-13", displayValue: "1-13 週一 第十三節" },
+
+          { key: "2-1", displayValue: "2-1 週二 第一節" },
+          { key: "2-2", displayValue: "2-2 週二 第二節" },
+          { key: "2-3", displayValue: "2-3 週二 第三節" },
+          { key: "2-4", displayValue: "2-4 週二 第四節" },
+          { key: "2-5", displayValue: "2-5 週二 第五節" },
+          { key: "2-6", displayValue: "2-6 週二 第六節" },
+          { key: "2-7", displayValue: "2-7 週二 第七節" },
+          { key: "2-8", displayValue: "2-8 週二 第八節" },
+          { key: "2-9", displayValue: "2-9 週二 第九節" },
+          { key: "2-10", displayValue: "2-10 週二 第十節" },
+          { key: "2-11", displayValue: "2-11 週二 第十一節" },
+          { key: "2-12", displayValue: "2-12 週二 第十二節" },
+          { key: "2-13", displayValue: "2-13 週二 第十三節" },
+
+          { key: "3-1", displayValue: "3-1 週三 第一節" },
+          { key: "3-2", displayValue: "3-2 週三 第二節" },
+          { key: "3-3", displayValue: "3-3 週三 第三節" },
+          { key: "3-4", displayValue: "3-4 週三 第四節" },
+          { key: "3-5", displayValue: "3-5 週三 第五節" },
+          { key: "3-6", displayValue: "3-6 週三 第六節" },
+          { key: "3-7", displayValue: "3-7 週三 第七節" },
+          { key: "3-8", displayValue: "3-8 週三 第八節" },
+          { key: "3-9", displayValue: "3-9 週三 第九節" },
+          { key: "3-10", displayValue: "3-10 週三 第十節" },
+          { key: "3-11", displayValue: "3-11 週三 第十一節" },
+          { key: "3-12", displayValue: "3-12 週三 第十二節" },
+          { key: "3-13", displayValue: "3-13 週三 第十三節" },
+
+          { key: "4-1", displayValue: "4-1 週四 第一節" },
+          { key: "4-2", displayValue: "4-2 週四 第二節" },
+          { key: "4-3", displayValue: "4-3 週四 第三節" },
+          { key: "4-4", displayValue: "4-4 週四 第四節" },
+          { key: "4-5", displayValue: "4-5 週四 第五節" },
+          { key: "4-6", displayValue: "4-6 週四 第六節" },
+          { key: "4-7", displayValue: "4-7 週四 第七節" },
+          { key: "4-8", displayValue: "4-8 週四 第八節" },
+          { key: "4-9", displayValue: "4-9 週四 第九節" },
+          { key: "4-10", displayValue: "4-10 週四 第十節" },
+          { key: "4-11", displayValue: "4-11 週四 第十一節" },
+          { key: "4-12", displayValue: "4-12 週四 第十二節" },
+          { key: "4-13", displayValue: "4-13 週四 第十三節" },
+
+          { key: "5-1", displayValue: "5-1 週五 第一節" },
+          { key: "5-2", displayValue: "5-2 週五 第二節" },
+          { key: "5-3", displayValue: "5-3 週五 第三節" },
+          { key: "5-4", displayValue: "5-4 週五 第四節" },
+          { key: "5-5", displayValue: "5-5 週五 第五節" },
+          { key: "5-6", displayValue: "5-6 週五 第六節" },
+          { key: "5-7", displayValue: "5-7 週五 第七節" },
+          { key: "5-8", displayValue: "5-8 週五 第八節" },
+          { key: "5-9", displayValue: "5-9 週五 第九節" },
+          { key: "5-10", displayValue: "5-10 週五 第十節" },
+          { key: "5-11", displayValue: "5-11 週五 第十一節" },
+          { key: "5-12", displayValue: "5-12 週五 第十二節" },
+          { key: "5-13", displayValue: "5-13 週五 第十三節" },
+
+          { key: "6-1", displayValue: "6-1 週六 第一節" },
+          { key: "6-2", displayValue: "6-2 週六 第二節" },
+          { key: "6-3", displayValue: "6-3 週六 第三節" },
+          { key: "6-4", displayValue: "6-4 週六 第四節" },
+          { key: "6-5", displayValue: "6-5 週六 第五節" },
+          { key: "6-6", displayValue: "6-6 週六 第六節" },
+          { key: "6-7", displayValue: "6-7 週六 第七節" },
+          { key: "6-8", displayValue: "6-8 週六 第八節" },
+          { key: "6-9", displayValue: "6-9 週六 第九節" },
+          { key: "6-10", displayValue: "6-10 週六 第十節" },
+          { key: "6-11", displayValue: "6-11 週六 第十一節" },
+          { key: "6-12", displayValue: "6-12 週六 第十二節" },
+          { key: "6-13", displayValue: "6-13 週六 第十三節" },
+
+          { key: "7-1", displayValue: "7-1 週日 第一節" },
+          { key: "7-2", displayValue: "7-2 週日 第二節" },
+          { key: "7-3", displayValue: "7-3 週日 第三節" },
+          { key: "7-4", displayValue: "7-4 週日 第四節" },
+          { key: "7-5", displayValue: "7-5 週日 第五節" },
+          { key: "7-6", displayValue: "7-6 週日 第六節" },
+          { key: "7-7", displayValue: "7-7 週日 第七節" },
+          { key: "7-8", displayValue: "7-8 週日 第八節" },
+          { key: "7-9", displayValue: "7-9 週日 第九節" },
+          { key: "7-10", displayValue: "7-10 週日 第十節" },
+          { key: "7-11", displayValue: "7-11 週日 第十一節" },
+          { key: "7-12", displayValue: "7-12 週日 第十二節" },
+          { key: "7-13", displayValue: "7-13 週日 第十三節" },
+        ],
+      },
+    },
+    keyword: {
+      key: "keyword",
+      displayValue: "關鍵字",
+      compareMethods: [
+        {
+          key: "includes",
+          displayValue: "包含",
+        },
+        {
+          key: "not-includes",
+          displayValue: "不包含",
+        },
+      ],
+      compareContent: {
+        inputType: InputType.Text,
+      },
+    },
+    type: {
+      key: "type",
+      displayValue: "修別",
+      compareMethods: [
+        {
+          key: "equals",
+          displayValue: "等於",
+        },
+        {
+          key: "not-equals",
+          displayValue: "不等於",
+        },
+      ],
+      compareContent: {
+        inputType: InputType.MultipleSelect,
+        selectables: [
+          { key: "required", displayValue: "必修" },
+          { key: "required-optional", displayValue: "必選" },
+          { key: "optional", displayValue: "選修" },
+          { key: "general", displayValue: "通識" },
+        ],
+      },
+    },
+  };
+
+  public filters: AnyFilter[] = [];
+
+  public searchHelperEnabled = new BehaviorSubject(false);
+
+  public enableSearchHelper(): void {
+    this.searchHelperEnabled.next(true);
+  }
+
+  public disableSearchHelper(): void {
+    this.searchHelperEnabled.next(false);
+  }
+
+  public toggleSearchHelper(): void {
+    this.searchHelperEnabled.next(!this.searchHelperEnabled.value);
+  }
+}
+
+export interface CompareMethod {
+  key: string;
+  displayValue: string;
+}
+
+export interface Filtrable<T extends InputType> {
+  key: string;
+  displayValue: string;
+  compareMethods: CompareMethod[];
+  compareContent: Comparable<T>;
+}
+
+export type AnyFiltrable = TextFiltrable | MultipleSelectFiltrable;
+
+export interface TextFiltrable extends Filtrable<InputType.Text> {
+  compareContent: ComparableText;
+}
+
+export interface MultipleSelectFiltrable
+  extends Filtrable<InputType.MultipleSelect> {
+  compareContent: ComparableMultipleSelect;
+}
+
+export enum InputType {
+  Text = "text",
+  MultipleSelect = "multiple-select",
+}
+
+export interface Comparable<T extends InputType> {
+  inputType: T;
+}
+
+export type AnyComparable = ComparableText | ComparableMultipleSelect;
+
+export interface ComparableText extends Comparable<InputType.Text> {}
+
+export interface ComparableMultipleSelect
+  extends Comparable<InputType.MultipleSelect> {
+  selectables: Selectable[];
+}
+
+export interface Selectable {
+  key: string;
+  displayValue: string;
+}
+
+export interface Filter<T extends InputType> {
+  filtering: Filtrable<T> | null;
+  compareMethod: CompareMethod | null;
+  compareContent: unknown;
+}
+
+export type AnyFilter = TextFilter | MultipleSelectFilter;
+
+export interface TextFilter extends Filter<InputType.Text> {
+  filtering: TextFiltrable | null;
+  compareContent: string | null;
+}
+
+export interface MultipleSelectFilter extends Filter<InputType.MultipleSelect> {
+  filtering: MultipleSelectFiltrable | null;
+  compareContent: Selectable[] | null;
+}


### PR DESCRIPTION
Search Helper is a set of UI that let users easily setup conditions by interact with it, instead of enter query string by themself.

Currently this feature can add, edit and remove conditions, options are provided by pre-filled fake data. Data are binding into search service, thus any interact to data will update to search service. It will auto refill data after turns helper on.
