### PR TITLE
ci: auto sort import

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "root": true,
   "ignorePatterns": ["projects/**/*"],
+  "plugins": ["simple-import-sort", "import"],
   "overrides": [
     {
       "files": ["*.ts"],
@@ -31,7 +32,11 @@
         "@typescript-eslint/explicit-function-return-type": "error",
         "@typescript-eslint/explicit-member-accessibility": "error",
         "@typescript-eslint/no-unused-vars": "error",
-        "sort-imports": "error"
+        "simple-import-sort/imports": "error",
+        "simple-import-sort/exports": "error",
+        "import/first": "error",
+        "import/newline-after-import": "error",
+        "import/no-duplicates": "error"
       }
     },
     {

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,6 @@
     "angular.ng-template",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "bradlc.vscode-tailwindcss",
-    "amatiasq.sort-imports"
+    "bradlc.vscode-tailwindcss"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-import-resolver-typescript": "^3.5.2",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-simple-import-sort": "^8.0.0",
     "husky": "^8.0.1",
     "jasmine-core": "~4.3.0",
     "karma": "~6.4.0",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,6 +1,5 @@
-import { RouterModule, Routes } from "@angular/router";
-
 import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
 
 const routes: Routes = [];
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,6 +1,7 @@
-import { AppComponent } from "./app.component";
-import { RouterTestingModule } from "@angular/router/testing";
 import { TestBed } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+
+import { AppComponent } from "./app.component";
 
 describe("AppComponent", () => {
   beforeEach(async () => {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,10 +1,11 @@
+import { NgModule } from "@angular/core";
+import { BrowserModule } from "@angular/platform-browser";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { ServiceWorkerModule } from "@angular/service-worker";
+
+import { environment } from "../environments/environment";
 import { AppComponent } from "./app.component";
 import { AppRoutingModule } from "./app-routing.module";
-import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { BrowserModule } from "@angular/platform-browser";
-import { NgModule } from "@angular/core";
-import { ServiceWorkerModule } from "@angular/service-worker";
-import { environment } from "../environments/environment";
 
 @NgModule({
   declarations: [AppComponent],

--- a/src/app/modules/search/components/search-helper-item/search-helper-item.component.spec.ts
+++ b/src/app/modules/search/components/search-helper-item/search-helper-item.component.spec.ts
@@ -1,3 +1,16 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { MatIconModule } from "@angular/material/icon";
+import { MatLegacyAutocompleteModule as MatAutocompleteModule } from "@angular/material/legacy-autocomplete";
+import { MatLegacyButtonModule as MatButtonModule } from "@angular/material/legacy-button";
+import { MatLegacyChipsModule as MatChipsModule } from "@angular/material/legacy-chips";
+import { MatLegacyFormFieldModule as MatFormFieldModule } from "@angular/material/legacy-form-field";
+import { MatLegacyInputModule as MatInputModule } from "@angular/material/legacy-input";
+import { MatLegacySelectModule as MatSelectModule } from "@angular/material/legacy-select";
+import { MatLegacyTooltipModule as MatTooltipModule } from "@angular/material/legacy-tooltip";
+import { By } from "@angular/platform-browser";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+
 import {
   AnyFilter,
   InputType,
@@ -5,19 +18,6 @@ import {
   SearchService,
   TextFiltrable,
 } from "../../search.service";
-import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { FormsModule, ReactiveFormsModule } from "@angular/forms";
-
-import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { By } from "@angular/platform-browser";
-import { MatLegacyAutocompleteModule as MatAutocompleteModule } from "@angular/material/legacy-autocomplete";
-import { MatLegacyButtonModule as MatButtonModule } from "@angular/material/legacy-button";
-import { MatLegacyChipsModule as MatChipsModule } from "@angular/material/legacy-chips";
-import { MatLegacyFormFieldModule as MatFormFieldModule } from "@angular/material/legacy-form-field";
-import { MatIconModule } from "@angular/material/icon";
-import { MatLegacyInputModule as MatInputModule } from "@angular/material/legacy-input";
-import { MatLegacySelectModule as MatSelectModule } from "@angular/material/legacy-select";
-import { MatLegacyTooltipModule as MatTooltipModule } from "@angular/material/legacy-tooltip";
 import { SearchHelperItemComponent } from "./search-helper-item.component";
 
 describe("SearchHelperItemComponent", () => {

--- a/src/app/modules/search/components/search-helper-item/search-helper-item.component.ts
+++ b/src/app/modules/search/components/search-helper-item/search-helper-item.component.ts
@@ -1,3 +1,8 @@
+import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
+import { FormControl } from "@angular/forms";
+import { MatLegacyAutocompleteSelectedEvent as MatAutocompleteSelectedEvent } from "@angular/material/legacy-autocomplete";
+import { BehaviorSubject } from "rxjs";
+
 import {
   AnyFilter,
   AnyFiltrable,
@@ -9,11 +14,6 @@ import {
   Selectable,
   TextFilter,
 } from "../../search.service";
-import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
-
-import { BehaviorSubject } from "rxjs";
-import { FormControl } from "@angular/forms";
-import { MatLegacyAutocompleteSelectedEvent as MatAutocompleteSelectedEvent } from "@angular/material/legacy-autocomplete";
 
 @Component({
   selector: "app-search-helper-item",

--- a/src/app/modules/search/components/search-helper/search-helper.component.spec.ts
+++ b/src/app/modules/search/components/search-helper/search-helper.component.spec.ts
@@ -1,15 +1,15 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
-
-import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { By } from "@angular/platform-browser";
+import { MatIconModule } from "@angular/material/icon";
 import { MatLegacyAutocompleteModule as MatAutocompleteModule } from "@angular/material/legacy-autocomplete";
 import { MatLegacyChipsModule as MatChipsModule } from "@angular/material/legacy-chips";
-import { MatIconModule } from "@angular/material/icon";
 import { MatLegacySelectModule as MatSelectModule } from "@angular/material/legacy-select";
-import { SearchHelperComponent } from "./search-helper.component";
-import { SearchHelperItemComponent } from "../search-helper-item/search-helper-item.component";
+import { By } from "@angular/platform-browser";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+
 import { SearchService } from "../../search.service";
+import { SearchHelperItemComponent } from "../search-helper-item/search-helper-item.component";
+import { SearchHelperComponent } from "./search-helper.component";
 
 describe("SearchHelperComponent", () => {
   let component: SearchHelperComponent;

--- a/src/app/modules/search/components/search-helper/search-helper.component.ts
+++ b/src/app/modules/search/components/search-helper/search-helper.component.ts
@@ -1,5 +1,6 @@
-import { AnyFilter, SearchService } from "../../search.service";
 import { Component, OnDestroy, OnInit } from "@angular/core";
+
+import { AnyFilter, SearchService } from "../../search.service";
 
 @Component({
   selector: "app-search-helper",

--- a/src/app/modules/search/search-routing.module.ts
+++ b/src/app/modules/search/search-routing.module.ts
@@ -1,6 +1,5 @@
-import { RouterModule, Routes } from "@angular/router";
-
 import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
 
 const routes: Routes = [];
 

--- a/src/app/modules/search/search.module.ts
+++ b/src/app/modules/search/search.module.ts
@@ -1,6 +1,6 @@
-import { FormsModule, ReactiveFormsModule } from "@angular/forms";
-
 import { CommonModule } from "@angular/common";
+import { NgModule } from "@angular/core";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { MatAutocompleteModule } from "@angular/material/autocomplete";
 import { MatButtonModule } from "@angular/material/button";
 import { MatChipsModule } from "@angular/material/chips";
@@ -9,7 +9,7 @@ import { MatIconModule } from "@angular/material/icon";
 import { MatInputModule } from "@angular/material/input";
 import { MatSelectModule } from "@angular/material/select";
 import { MatTooltipModule } from "@angular/material/tooltip";
-import { NgModule } from "@angular/core";
+
 import { SearchHelperComponent } from "./components/search-helper/search-helper.component";
 import { SearchHelperItemComponent } from "./components/search-helper-item/search-helper-item.component";
 import { SearchRoutingModule } from "./search-routing.module";

--- a/src/app/modules/search/search.service.spec.ts
+++ b/src/app/modules/search/search.service.spec.ts
@@ -1,5 +1,6 @@
-import { SearchService } from "./search.service";
 import { TestBed } from "@angular/core/testing";
+
+import { SearchService } from "./search.service";
 
 describe("SearchService", () => {
   let service: SearchService;

--- a/src/app/modules/search/search.service.ts
+++ b/src/app/modules/search/search.service.ts
@@ -1,5 +1,5 @@
-import { BehaviorSubject } from "rxjs";
 import { Injectable } from "@angular/core";
+import { BehaviorSubject } from "rxjs";
 
 @Injectable({
   providedIn: "root",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,8 @@
-import { AppModule } from "./app/app.module";
 import { enableProdMode } from "@angular/core";
-import { environment } from "./environments/environment";
 import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
+
+import { AppModule } from "./app/app.module";
+import { environment } from "./environments/environment";
 
 if (environment.production) {
   enableProdMode();

--- a/src/test.ts
+++ b/src/test.ts
@@ -2,12 +2,11 @@
 
 import "zone.js/testing";
 
+import { getTestBed } from "@angular/core/testing";
 import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting,
 } from "@angular/platform-browser-dynamic/testing";
-
-import { getTestBed } from "@angular/core/testing";
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4701,6 +4701,11 @@ eslint-plugin-prettier@^4.2.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-simple-import-sort@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-8.0.0.tgz#9d9a2372b0606e999ea841b10458a370a6ccc160"
+  integrity sha512-bXgJQ+lqhtQBCuWY/FUWdB27j4+lqcvXv5rUARkzbeWLwea+S5eBZEQrhnO+WgX3ZoJHVj0cn943iyXwByHHQw==
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
Currently we're using VSCode plugins to help us sort imports, and use eslint to validate code.

The base reason is eslint or prettier itself does not provide a default import sorting feature, so we choose an alternative way to achieve that.

Though this is work, there are better ways that we can install some plugins of eslint, then we can use eslint itself to auto sort our imports.
